### PR TITLE
Fix invalid method name

### DIFF
--- a/lib/berkshelf/locations/hg.rb
+++ b/lib/berkshelf/locations/hg.rb
@@ -5,7 +5,7 @@ require 'berkshelf'
 
 module Berkshelf
   class HgLocation < BaseLocation
-    class HgError < BerkshelfError; status_code(500); end
+    class HgError < BerkshelfError; set_status_code(500); end
 
     class HgNotInstalled < HgError
       def initialize


### PR DESCRIPTION
The BerkshelfError class has a method named 'set_status_code' yet it's spelled wrong in HgError so
returns invalid method.